### PR TITLE
docs: 添加 License 徽章至 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nhm-django-infra
 
 [![Coverage badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/noHairMan/nhm-django-infra/python-coverage-comment-action-data/endpoint.json)](https://htmlpreview.github.io/?https://github.com/noHairMan/nhm-django-infra/blob/python-coverage-comment-action-data/htmlcov/index.html)
+![GitHub License](https://img.shields.io/github/license/noHairMan/nhm-django-infra)
 
 A lightweight Django 5 + Django REST framework boilerplate for backend services. It includes:
 


### PR DESCRIPTION
- 在 README.md 文件中新增 License 徽章，用于展示项目许可证类型；
- 提供链接跳转，方便开发者快速了解项目许可信息；
- 改善文档的可视化效果，提升项目的专业性与易用性。