### PR TITLE
feat: 添加测试用例以覆盖通用视图和分页功能

### DIFF
--- a/src/porsche/core/restframework/__init__.py
+++ b/src/porsche/core/restframework/__init__.py
@@ -31,4 +31,8 @@ __all__ = [
     "PorscheDestroyModelMixin",
     "PorscheListModelMixin",
     "PorscheRetrieveModelMixin",
+    "PorscheResponse",
+    "PorscheRequest",
+    "PorschePageNumberPagination",
+    "PorscheServerException",
 ]

--- a/src/porsche/tests/core/restframework/__init__.py
+++ b/src/porsche/tests/core/restframework/__init__.py
@@ -1,5 +1,7 @@
 from .exceptions import *
 from .fields import *
+from .generic import *
+from .pagination import *
 from .response import *
 from .view import *
 from .viewsets import *

--- a/src/porsche/tests/core/restframework/generic.py
+++ b/src/porsche/tests/core/restframework/generic.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+from rest_framework.response import Response
+
+from porsche.core.restframework import (
+    PorscheAPITestCase,
+    PorscheGenericAPIView,
+    PorscheResponse,
+    PorscheSerializer,
+    PorscheServerException,
+)
+from porsche.models.enums import ViewAction
+
+
+class TestGeneric(PorscheAPITestCase):
+    def test_porsche_generic_api_view(self):
+        class CreateSerializer(PorscheSerializer):
+            pass
+
+        class UpdateSerializer(PorscheSerializer):
+            pass
+
+        class RetrieveSerializer(PorscheSerializer):
+            pass
+
+        class ListSerializer(PorscheSerializer):
+            pass
+
+        class TestViewSet(PorscheGenericAPIView):
+            create_serializer_class = CreateSerializer
+            update_serializer_class = UpdateSerializer
+            retrieve_serializer_class = RetrieveSerializer
+            list_serializer_class = ListSerializer
+
+        request = self.request_factory.get("test")
+        self.assertEqual(
+            TestViewSet(request=request, format_kwarg={}, action=ViewAction.CREATE).get_serializer_class(),
+            CreateSerializer,
+        )
+        self.assertEqual(
+            TestViewSet(request=request, format_kwarg={}, action=ViewAction.UPDATE).get_serializer_class(),
+            UpdateSerializer,
+        )
+        self.assertEqual(
+            TestViewSet(request=request, format_kwarg={}, action=ViewAction.RETRIEVE).get_serializer_class(),
+            RetrieveSerializer,
+        )
+        self.assertEqual(
+            TestViewSet(request=request, format_kwarg={}, action=ViewAction.LIST).get_serializer_class(),
+            ListSerializer,
+        )
+        self.assertEqual(
+            TestViewSet(request=request, format_kwarg={}, action=ViewAction.METADATA).get_serializer_class(),
+            PorscheSerializer,
+        )
+
+        self.assertIsInstance(
+            TestViewSet(request=request, format_kwarg={}, action=ViewAction.METADATA).finalize_response(
+                request,
+                Response(),
+            ),
+            PorscheResponse,
+        )
+        with self.assertRaises(PorscheServerException):
+            TestViewSet(request=request, format_kwarg={}, action=ViewAction.METADATA).finalize_response(request, Any)

--- a/src/porsche/tests/core/restframework/pagination.py
+++ b/src/porsche/tests/core/restframework/pagination.py
@@ -1,0 +1,33 @@
+from porsche.core.restframework import (
+    PorscheAPITestCase,
+    PorschePageNumberPagination,
+    PorscheRequest,
+    PorscheResponse,
+)
+from porsche.models import Tag
+
+
+class TestPaginator(PorscheAPITestCase):
+    def setUp(self):
+        Tag.objects.bulk_create([Tag(name=f"tag_{i}", category=Tag.Category.COMPANY) for i in range(100)])
+
+    def test_porsche_page_number_pagination(self):
+        paginator = PorschePageNumberPagination()
+        self.assertEqual(
+            paginator.get_paginated_response_schema({}),
+            {
+                "type": "object",
+                "required": ["count", "results"],
+                "properties": {
+                    "count": {"type": "integer", "example": 123},
+                    "page": {"type": "integer", "example": 2},
+                    "size": {"type": "integer", "example": 50},
+                    "results": {},
+                },
+            },
+        )
+        request = PorscheRequest(self.request_factory.get("/api/tag?page=1&size=10"))
+        paginator.paginate_queryset(Tag.objects.all(), request, view=None)
+        response = paginator.get_paginated_response({})
+        self.assertIsInstance(response, PorscheResponse)
+        self.assertEqual(response.data["data"], {"count": 100, "page": 1, "size": 10, "results": {}})


### PR DESCRIPTION
- 新增 `TestGeneric` 测试类，覆盖通用视图的序列化器逻辑及响应处理；
- 添加 `TestPaginator` 测试类，验证分页实现的正确性及响应格式；
- 更新 `__init__.py` 文件中的模块导入，确保功能模块可被正确检索；
- 优化测试覆盖率，确保通用视图与分页功能的稳定性与可靠性。