### PR TITLE
refactor: 重构异常处理逻辑与视图实现

### DIFF
--- a/src/porsche/core/exceptions.py
+++ b/src/porsche/core/exceptions.py
@@ -1,6 +1,3 @@
-from rest_framework.exceptions import _get_error_details
-
-
 class PorscheException(Exception):
     default_detail = "An error occurred."
 
@@ -8,7 +5,7 @@ class PorscheException(Exception):
         if detail is None:
             detail = self.default_detail
 
-        self.detail = _get_error_details(detail)
+        self.detail = detail
 
     def __str__(self):
         return str(self.detail)

--- a/src/porsche/core/restframework/exceptions.py
+++ b/src/porsche/core/restframework/exceptions.py
@@ -1,14 +1,33 @@
-from rest_framework.exceptions import APIException
+from django.utils.encoding import force_str
+from django.utils.translation import gettext_lazy
+from rest_framework.exceptions import APIException, ErrorDetail
 
 from porsche.core.exceptions import PorscheException
 from porsche.models.enums import BusinessCode
 
 
+def get_error_details(data, default_code=None):
+    if isinstance(data, (list, tuple)):
+        ret = [get_error_details(item, default_code) for item in data]
+        return ", ".join(value for value in ret)
+    elif isinstance(data, dict):
+        ret = {key: get_error_details(value, default_code) for key, value in data.items()}
+        return ", ".join(f"{key}: {value}" for key, value in ret.items())
+
+    text = force_str(data)
+    code = getattr(data, "code", default_code)
+    return ErrorDetail(text, code)
+
+
 class PorscheAPIException(APIException, PorscheException):
     business_code = BusinessCode.BAD_REQUEST
-    message = "Api Exception"
+    message = gettext_lazy("Api Exception")
+
+    def __init__(self, detail=None, code=None):
+        super().__init__(detail, code)
+        self.detail = get_error_details(detail, code)
 
 
 class PorscheServerException(PorscheException):
     business_code = BusinessCode.SERVER_ERROR
-    message = "Server Exception"
+    message = gettext_lazy("Server Exception")

--- a/src/porsche/core/restframework/views.py
+++ b/src/porsche/core/restframework/views.py
@@ -51,10 +51,7 @@ def exception_handler(exc: Any, context) -> PorscheResponse:
         if wait := getattr(exc, "wait", None):
             headers["Retry-After"] = "%d" % wait
 
-        if isinstance(exc.detail, (list, dict)):
-            message = ujson.dumps(exc.detail, ensure_ascii=False, escape_forward_slashes=False)
-        else:
-            message = exc.detail
+        message = exc.detail
         set_rollback()
         return PorscheResponse(code=exc.business_code, headers=headers, message=message or exc.message)
     # any other exception, raise server error.

--- a/src/porsche/tests/core/restframework/view.py
+++ b/src/porsche/tests/core/restframework/view.py
@@ -1,11 +1,9 @@
-from pyexpat.errors import messages
-
 import ujson
 from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
 from django.http import Http404
-from rest_framework.exceptions import APIException, _get_error_details
+from rest_framework.exceptions import APIException
 
-from porsche.core.restframework.exceptions import PorscheAPIException
+from porsche.core.restframework.exceptions import PorscheAPIException, get_error_details
 from porsche.core.restframework.request import PorscheRequest
 from porsche.core.restframework.response import PorscheResponse
 from porsche.core.restframework.test import PorscheAPITestCase
@@ -52,7 +50,16 @@ class TestView(PorscheAPITestCase):
         self.assertEqual(response.business_code, BusinessCode.BAD_REQUEST)
         self.assertEqual(
             response.data["message"],
-            ujson.dumps(_get_error_details(message), ensure_ascii=False, escape_forward_slashes=False),
+            get_error_details(message),
+        )
+
+        message = [{"foo": "bar", "code": 123, "message": "test error"}]
+        response = self.exception_handler(PorscheAPIException(message), {})
+        self.assertIsInstance(response, PorscheResponse)
+        self.assertEqual(response.business_code, BusinessCode.BAD_REQUEST)
+        self.assertEqual(
+            response.data["message"],
+            get_error_details(message),
         )
 
         response = self.exception_handler(Exception("测试异常handler"), {})


### PR DESCRIPTION
- 删除 `_get_error_details` 的直接引用，统一使用自定义 `get_error_details`;
- 重构 PorscheException 和 PorscheAPIException 实现，改进异常 detail 处理逻辑;
- 调整视图中异常处理代码，简化 detail 与 message 的处理;
- 添加测试用例以覆盖新的 `get_error_details` 逻辑;
- 优化异常消息输出的可读性与一致性，提升日志调试效率。